### PR TITLE
Add API endpoint to fetch logs

### DIFF
--- a/src/doplarr/state.clj
+++ b/src/doplarr/state.clj
@@ -7,3 +7,5 @@
 (def discord (atom nil))
 
 (def config (atom nil))
+
+(def updated-data (atom nil))


### PR DESCRIPTION
Add functionality to fetch and display log data from the Sonarr API.

* **Fetch API Data**
  - Add `fetch-api-data` function in `src/doplarr/core.clj` to periodically fetch data from the Sonarr API and update the state.
  - Call `fetch-api-data` during bot startup in `startup!` function.

* **Update State**
  - Add `updated-data` atom in `src/doplarr/state.clj` to store the fetched data.

* **Modify Request Performed Plain**
  - Modify `request-performed-plain` function in `src/doplarr/discord.clj` to accept `logger` and `message` parameters and concatenate them with a newline.

* **Update Interaction Response**
  - Add `update-interaction-response!` function in `src/doplarr/discord.clj` to update the interaction response with the new message content whenever the data changes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jojohnathon/Doplarr/pull/1?shareId=cc71ce2f-8ce7-495d-b973-d7c743d07782).